### PR TITLE
working on osx and updated jenkins docker image and jenkins plugin versions

### DIFF
--- a/bootstrap/01-insert-secrets.sh
+++ b/bootstrap/01-insert-secrets.sh
@@ -10,9 +10,9 @@ DH=dhparam.pem
 CERTS_DIR=certs
 
 echo "Encoding secrets into kubernetes secrets file..."
-crt=`base64 -w 0 ${CERTS_DIR}/${CERT}.crt`
-key=`base64 -w 0 ${CERTS_DIR}/${CERT}.key`
-dh=`base64 -w 0 ${CERTS_DIR}/dhparam.pem`
+crt=`base64 -i ${CERTS_DIR}/${CERT}.crt`
+key=`base64 -i ${CERTS_DIR}/${CERT}.key`
+dh=`base64 -i ${CERTS_DIR}/dhparam.pem`
 
 echo "Creating secrets file from template..."
 

--- a/bootstrap/10-jenkins-master-templates.sh
+++ b/bootstrap/10-jenkins-master-templates.sh
@@ -28,9 +28,9 @@ if [ ! -f ${CERTS_DIR}/${KH} ]; then
 fi
 
 echo "Encoding..."
-key=`base64 -w 0 ${CERTS_DIR}/${KEY}`
-keypub=`base64 -w 0 ${CERTS_DIR}/${KEY}.pub`
-kh=`base64 -w 0 ${CERTS_DIR}/${KH}`
+key=`base64 -i ${CERTS_DIR}/${KEY}`
+keypub=`base64 -i ${CERTS_DIR}/${KEY}.pub`
+kh=`base64 -i ${CERTS_DIR}/${KH}`
 
 echo "Creating secrets file from template..."
 

--- a/bootstrap/docker-build-and-upload.sh
+++ b/bootstrap/docker-build-and-upload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 
 NAME=$1

--- a/bootstrap/docker/jenkins-dind-slave/Dockerfile
+++ b/bootstrap/docker/jenkins-dind-slave/Dockerfile
@@ -4,9 +4,10 @@ MAINTAINER anonim@no.ne
 RUN apt-get update -y && apt-get upgrade -y
 RUN apt-get install -y apt-transport-https
 # Add the repository to your APT sources
-RUN echo deb https://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list 
+RUN echo deb https://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 # Then import the repository key
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+#RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
 # Let's start with some basic stuff.
 RUN apt-get update -qq && apt-get install -qqy \
@@ -28,27 +29,26 @@ RUN useradd -c "Jenkins agent" -d $HOME -m jenkins-agent
 RUN usermod -aG docker jenkins-agent
 RUN curl --create-dirs -sSLo \
     /usr/share/jenkins/swarm-client-jar-with-dependencies.jar \
-    http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/1.22/swarm-client-1.22-jar-with-dependencies.jar \
+    http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/2.0/swarm-client-2.0-jar-with-dependencies.jar \
     && chmod 755 /usr/share/jenkins
 
 # Install gcloud
 ENV CLOUDSDK_PYTHON_SITEPACKAGES 1
-RUN apt-get install -y -qq --no-install-recommends wget unzip python php5-mysql php5-cli php5-cgi openjdk-7-jre-headless openssh-client python-openssl \
+RUN apt-get install -y -qq --no-install-recommends wget unzip python openjdk-7-jre-headless openssh-client python-openssl \
   && cd /home/jenkins-agent \
   && wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip \
   && google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --disable-installation-options \
   && google-cloud-sdk/bin/gcloud --quiet components update pkg-go pkg-python pkg-java preview app \
   && google-cloud-sdk/bin/gcloud --quiet config set component_manager/disable_update_check true \
   && chown -R jenkins-agent /home/jenkins-agent/.config \
-  && chown -R jenkins-agent google-cloud-sdk 
+  && chown -R jenkins-agent google-cloud-sdk
 ENV PATH /home/jenkins-agent/google-cloud-sdk/bin:$PATH
 
 # cleanup
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Run Docker and Swarm processe with supervisord 
+# Run Docker and Swarm processe with supervisord
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY jenkins-docker-supervisor.sh /usr/local/bin/jenkins-docker-supervisor.sh
 ENTRYPOINT ["/usr/local/bin/jenkins-docker-supervisor.sh"]
-

--- a/bootstrap/docker/jenkins-master/Dockerfile
+++ b/bootstrap/docker/jenkins-master/Dockerfile
@@ -14,7 +14,7 @@
 # jenkins-gcp-leader
 #
 # VERSION   0.0.2
-FROM jenkins:1.609.1
+FROM jenkins
 
 MAINTAINER piontec
 

--- a/bootstrap/docker/jenkins-master/jenkins/scm-sync-configuration.xml
+++ b/bootstrap/docker/jenkins-master/jenkins/scm-sync-configuration.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <hudson.plugins.scm__sync__configuration.ScmSyncConfigurationPlugin version="1">
   <scm class="hudson.plugins.scm_sync_configuration.scms.ScmSyncGitSCM"/>
-  <scmRepositoryUrl>scm:git:git@yourhost/user:repo.git</scmRepositoryUrl>
+  <scmRepositoryUrl>scm:git:git@bitbucket.org:savethatname/jenkins_backup.git</scmRepositoryUrl>
   <noUserCommitMessage>false</noUserCommitMessage>
   <displayStatus>true</displayStatus>
   <commitMessagePattern>[message]</commitMessagePattern>

--- a/bootstrap/docker/jenkins-master/plugins.txt
+++ b/bootstrap/docker/jenkins-master/plugins.txt
@@ -1,7 +1,7 @@
 scm-api:0.2
-swarm:1.22
-git-client:1.16.1
-git:2.3.5
+swarm:2.0
+git-client:1.19.0
+git:2.4.0
 oauth-credentials:0.3
 google-oauth-plugin:0.3
 google-metadata-plugin:0.2
@@ -10,4 +10,3 @@ google-source-plugin:0.1
 scm-sync-configuration:0.0.8
 locale:1.2
 token-macro:1.10
-msbuild


### PR DESCRIPTION
This has been tested on osx 10.9 and 10.10. I have not tested it on other platforms. However the all_down and all_up commands have worked for me on numerous occasions now on osx. The most critical of changes is making sure the switches passed to base64 are still compatible with your original platform.
